### PR TITLE
JWT Token 보안 강화

### DIFF
--- a/accounts/views.py
+++ b/accounts/views.py
@@ -6,13 +6,14 @@ from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.views import APIView
 from drfpasswordless.serializers import CallbackTokenAuthSerializer
 from drfpasswordless.settings import api_settings
-
+from rest_framework_simplejwt.views import TokenRefreshView, TokenObtainPairView
 
 # logger = logging.getLogger(__name__)
 
 class ObtainJWTTokenFromCallbackToken(APIView):
     """
     Returns JWT Token(access, refresh) based on our callback token and source.
+    Store refresh Token in HttpOnly Cookie.
     """
     permission_classes = (AllowAny,)
     serializer_class = CallbackTokenAuthSerializer
@@ -23,6 +24,26 @@ class ObtainJWTTokenFromCallbackToken(APIView):
             user = serializer.validated_data["user"]
             token_creator = import_string(api_settings.PASSWORDLESS_AUTH_TOKEN_CREATOR)
             (token, _) = token_creator(user)
-            return Response(token, status=status.HTTP_200_OK)
+            response = Response({'access_token': token['access_token']}, status=status.HTTP_200_OK)
+            cookie_max_age = 3600 * 24 * 14  # 14 days
+            response.set_cookie(
+                key='refresh_token',
+                value=token['refresh_token'],
+                max_age=cookie_max_age,
+                secure=False,  # https 연결에서만 쿠키 전송
+                httponly=True,
+                samesite='Lax'
+            )
+            return response
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 
+class CookieTokenRefreshView(TokenRefreshView):
+    """
+    Refresh access Token by refresh Token.
+    Refresh token is stored in HttpOnly Cookie.
+    """
+    def initialize_request(self, request, *args, **kwargs):
+        drf_request = super().initialize_request(request, *args, **kwargs)
+        drf_request.data['refresh_token'] = request.COOKIES.get('refresh')
+        return drf_request

--- a/murok_backend/settings.py
+++ b/murok_backend/settings.py
@@ -184,10 +184,7 @@ from datetime import timedelta
 # Simple JWT
 SIMPLE_JWT = {
     'ACCESS_TOKEN_LIFETIME': timedelta(minutes=60),  # AccessToken 수명 설정
-    'SLIDING_TOKEN_REFRESH_LIFETIME': timedelta(days=1),  # SlidingToken 갱신 시간 설정
-    'SLIDING_TOKEN_LIFETIME': timedelta(days=7),  # SlidingToken 수명 설정
-    'SLIDING_TOKEN_REFRESH_LIFETIME_ALGORITHM': 'same-origin',  # SlidingToken 갱신 알고리즘 설정
-    'SLIDING_TOKEN_REFRESH_COMPARED_TO_ACCESS_TOKEN': False,  # SlidingToken 갱신 여부 설정
+    'REFRESH_TOKEN_LIFETIME': timedelta(days=14),  # RefreshToken 수명 설정
 }
 
 # Passwordless Auth


### PR DESCRIPTION
### 개요
JWT 보안 강화
- access token은 response에, refresh token은 HttpOnly Cookie에서 관리

### 작업사항
- accounts/views.py
  > __ObtainJWTTokenFromCallbackToken__
  인증 코드 인증 완료 후 JWT Token 반환시, 
  Access token은 Response body에
  Refresh token은 HttpOnly Cookie에 저장

  > __CookieTokenRefreshView__
  javascript에선 HttpOnly Cookie를 읽어올 수 없으므로,
  initialize_request 에서 Cookie에 있는 값을 request.data에 미리 저장
  
- settings.py
  > Refresh Token의 lifetime 설정 추가
  Sliding Token 관련 설정 삭제

### 추후 작업 예정 및 고민 사항
[💭] Https 적용이 된다면, cookie에 secure 속성 추가
  - https 연결에서만 cookie를 전송하도록 보장

[💭] Access token도 HttpOnly Cookie에 저장할지?


### 관련 화면
![image](https://github.com/SummitCapstone/murok_backend/assets/95182422/436bc1f4-06ce-4917-aa9b-0120dfc821bf)



### 참고 자료
- [Refresh Token을 HttpOnly Cookie에 저장하는 방법 - 이 중 두번째 답변 참고함](https://stackoverflow.com/questions/66247988/how-to-store-jwt-tokens-in-httponly-cookies-with-drf-djangorestframework-simplej)
- [HttpOnly Cookie에 있는 refresh token 값 request.data에 가져오기](https://www.inflearn.com/questions/931442/token%EC%9D%84-cookie%EC%97%90-%EC%A0%80%EC%9E%A5%ED%95%98%EB%8A%94-%EA%B2%83%EC%97%90-%EA%B4%80%ED%95%9C-%EC%97%90%EB%9F%AC-%EC%A7%88%EB%AC%B8)
- [jwt + csrf_token에 대하여](https://stackoverflow.com/questions/27067251/where-to-store-jwt-in-browser-how-to-protect-against-csrf)
